### PR TITLE
Fix incorrect distro name

### DIFF
--- a/overview.md
+++ b/overview.md
@@ -58,6 +58,6 @@ The currently supported vGPU host driver does not natively compile against Linux
 #### Guest
 
 * Red Hat Enterprise Linux (and variants)
-* Debian 20.04 LTS (and variants)
+* Ubuntu 20.04 LTS (and variants)
 * Windows 8.1+ (including Server)
 * Plenty more not listed here.


### PR DESCRIPTION
I noticed when I visited the website, there was a error in the wiki where it said Debian instead of Ubuntu for the supported guest OS list.